### PR TITLE
Allow labels overriding for ingress.yaml template

### DIFF
--- a/chart/bitwarden-k8s/templates/ingress.yaml
+++ b/chart/bitwarden-k8s/templates/ingress.yaml
@@ -16,6 +16,9 @@ metadata:
     helm.sh/chart: {{ include "bitwarden-k8s.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}


### PR DESCRIPTION
When allowing labels for ingress.yaml template we can easily use kcert to handle SSL cert management, cf.: https://github.com/nabsul/kcert. Works fine for me with no other overhead ;)